### PR TITLE
Fix return value

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,5 +2,8 @@ homepage: "https://github.com/gtm-templates-knowit-experience/"
 documentation: "https://github.com/gtm-templates-knowit-experience/sgtm-split-string-variable"
 versions:
   # Latest version
+  - sha: 614f1a77ba4365208a1a57a9243b80ebbd954982
+    changeNotes: Initial release.
+  # Older versions
   - sha: 40617e63f1ebddec722b8ba759415f54c5d913ee
     changeNotes: Initial release.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,7 +3,7 @@ documentation: "https://github.com/gtm-templates-knowit-experience/sgtm-split-st
 versions:
   # Latest version
   - sha: 614f1a77ba4365208a1a57a9243b80ebbd954982
-    changeNotes: Initial release.
+    changeNotes: Fix return value for possible falsy input values.
   # Older versions
   - sha: 40617e63f1ebddec722b8ba759415f54c5d913ee
     changeNotes: Initial release.

--- a/template.js
+++ b/template.js
@@ -1,0 +1,30 @@
+const makeString = require('makeString');
+const makeNumber = require('makeNumber');
+// const log = require('logToConsole');
+
+if (!data.input) return undefined;
+
+const input = makeString(data.input);
+const delimiter = data.delimiter === 'space' ? ' ' : data.delimiter;
+const parts = input.split(delimiter);
+
+let index;
+switch (data.returnValue) {
+  case 'first':
+    index = 0;
+    break;
+  case 'last':
+    index = parts.length-1;
+    break;
+  case 'nthStart':
+    index = data.nthValue;
+    break;
+  case 'nthEnd':
+    index = parts.length-data.nthValue;
+    break;
+}
+
+const limit = data.limitReturn ? (makeNumber(index)+makeNumber(data.limitReturn)) : parts.length;
+const result = data.returnAllAfterSplit ? parts.slice(index,limit).join(delimiter) : parts[index];
+if (!result) return undefined;
+return result;

--- a/template.tpl
+++ b/template.tpl
@@ -177,14 +177,16 @@ ___SANDBOXED_JS_FOR_SERVER___
 
 const makeString = require('makeString');
 const makeNumber = require('makeNumber');
-const log = require('logToConsole');
+// const log = require('logToConsole');
+
+if (!data.input) return undefined;
 
 const input = makeString(data.input);
 const delimiter = data.delimiter === 'space' ? ' ' : data.delimiter;
 const parts = input.split(delimiter);
 
 let index;
-switch(data.returnValue) {
+switch (data.returnValue) {
   case 'first':
     index = 0;
     break;
@@ -200,37 +202,9 @@ switch(data.returnValue) {
 }
 
 const limit = data.limitReturn ? (makeNumber(index)+makeNumber(data.limitReturn)) : parts.length;
-const result = data.returnAllAfterSplit ? parts.slice(index,limit).join(delimiter): parts[index];
-if(result) {
-  return result;
-}
-
-
-___SERVER_PERMISSIONS___
-
-[
-  {
-    "instance": {
-      "key": {
-        "publicId": "logging",
-        "versionId": "1"
-      },
-      "param": [
-        {
-          "key": "environments",
-          "value": {
-            "type": 1,
-            "string": "debug"
-          }
-        }
-      ]
-    },
-    "clientAnnotations": {
-      "isEditedByUser": true
-    },
-    "isRequired": true
-  }
-]
+const result = data.returnAllAfterSplit ? parts.slice(index,limit).join(delimiter) : parts[index];
+if (!result) return undefined;
+return result;
 
 
 ___TESTS___
@@ -241,5 +215,4 @@ scenarios: []
 ___NOTES___
 
 Created on 2/22/2022, 9:15:48 PM
-
 


### PR DESCRIPTION
Hi @EivindSavio,

I noticed that when the variable is fed with a falsy value (like `undefined`), it may return `"undefined"` (as string), which is not desirable.

I added a condition to check this case, removed the unused `logToConsole` import, and refactored the `result` variable checking to avoid nested blocks.